### PR TITLE
Add accepts_nested_attributes_for support for delegated_type

### DIFF
--- a/lib/delegated_type.rb
+++ b/lib/delegated_type.rb
@@ -137,6 +137,21 @@ module ActiveRecord
   #   end
   #
   # Now you can list a bunch of entries, call +Entry#title+, and polymorphism will provide you with the answer.
+  #
+  # == Nested Attributes
+  #
+  # Enabling nested attributes on a delegated_type association allows you to
+  # create the entry and message in one go:
+  #
+  #   class Entry < ApplicationRecord
+  #     delegated_type :entryable, types: %w[ Message Comment ]
+  #     accepts_nested_attributes_for :entryable
+  #   end
+  #
+  #   params = { entry: { entryable_type: 'Message', entryable_attributes: { subject: 'Smiling' } } }
+  #   entry = Entry.create(params[:entry])
+  #   entry.entryable.id # => 2
+  #   entry.entryable.subject # => 'Smiling'
   module DelegatedType
     # Defines this as a class that'll delegate its type for the passed +role+ to the class references in +types+.
     # That'll create a polymorphic +belongs_to+ relationship to that +role+, and it'll add all the delegated
@@ -184,6 +199,10 @@ module ActiveRecord
 
         define_method "#{role}_name" do
           public_send("#{role}_class").model_name.singular.inquiry
+        end
+
+        define_method "build_#{role}" do |*params|
+          public_send("#{role}=", public_send("#{role}_class").new(*params))
         end
 
         types.each do |type|


### PR DESCRIPTION
Previously, trying to use nested attributes would raise an error when trying to build polymorphic associations:

```ruby
Entry.create(entryable_type: 'Message', entryable_attributes: { content: 'Hello world' })
# ArgumentError: Cannot build association `entryable'. Are you trying to build a polymorphic one-to-one association?
```

Adding this, matches the rails core implementation and prevents using have to add `build_#{role}` methods every time we introduce a nested association, which was a suggestion on Stack Overflow (https://stackoverflow.com/a/45306832), eg:

```ruby
def build_attachable(params)
  self.attachable = attachable_type.constantize.new(params)
end
```

The pull request first appeared in v7.0.0.rc1, here: https://github.com/rails/rails/pull/41717/files

We've since forked this and using it in our app at Zapnito

From the original PR:

> ### Summary
> 
> This PR adds `nested_attributes_for` support to `delegated_type`, this allows a developer to create and update records easily without needing to write specific methods like:
> 
> ```ruby
> class Entry < ApplicationRecord
>   delegated_type :entryable, types: %w[ Message Comment ]
> 
>   def self.create_with_comment(content, creator: Current.user)
>     create! entryable: Comment.new(content: content), creator: creator
>   end
> end
> ```
> 
> Using `nested_attributes_for` allows to execute the following:
> 
> ```ruby
> class Entry < ApplicationRecord
>   delegated_type :entryable, types: %w[ Message Comment ]
>   accepts_nested_attributes_for :entryable
> end
> 
> params = { entry: { entryable_type: 'Comment', entryable_attributes: { content: 'Smiling' } } }
> entry = Entry.create(params[:entry])
> ```
> 
> ### Why
> 
> Nested forms based on `accepts_nested_attributes_for` are very powerful and this is the last piece missing to also be able to use it on Delegated Types.
> ### Question
> 
> Since this is a polymorphic `belongs_to` relationship, what other tests would we like to have? As it is already tested in `TestNestedAttributesOnABelongsToAssociation`